### PR TITLE
Fix redirect loop by urldecoding the path

### DIFF
--- a/src/PathProcessor/ImageStylePathProcessor.php
+++ b/src/PathProcessor/ImageStylePathProcessor.php
@@ -23,7 +23,7 @@ class ImageStylePathProcessor implements InboundPathProcessorInterface {
         $imageStyle = $pathParts[0];
         array_shift($pathParts);
         $uriBase = array_shift($pathParts);
-        $imgUri = $uriBase . '://' . implode('/', $pathParts);
+        $imgUri = $uriBase . '://' . rawurldecode(implode('/', $pathParts));
 
         $style = \Drupal::entityTypeManager()
           ->getStorage('image_style')


### PR DESCRIPTION
Fix redirect loop by urldecoding the path

When building the path we get an encoded path. Passing this to buildUri additionally encodes the path. This leads to redirection loop as the original file can't be found. 

**Currently**
some file.jpg   -->  [...]/some%20file.jpg  --> buildUri([...]/some%20file.jpg) --> [...]/some%2520file.jpg --> 
buildUri([...]/some%2520file.jpg) --> [...]/some%252520file.jpg -->  ...


**With fix**
some file.jpg   -->  [...]/some%20file.jpg  --> buildUri([...]/some file.jpg) --> [...]/some%20file.jpg --> Resolved


